### PR TITLE
Jenkins lts java incompatibility

### DIFF
--- a/box/helm/jenkins-values.yml
+++ b/box/helm/jenkins-values.yml
@@ -1,6 +1,6 @@
 controller:
   image: "jenkins/jenkins"
-  tag: "lts"
+  tag: "2.319.3"
   adminPassword: "dynatrace"
   numExecutors: 2
   disableRememberMe: false


### PR DESCRIPTION
jenkins lts java version (55) is incompatible with the java version (52) on jenkins agent for the monaco runner